### PR TITLE
Improve request headers and error reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,10 +13,24 @@ def fetch_price_data(card):
     if card.get("holo"):
         query_parts.append("holo")
     query = "+".join(str(part) for part in query_parts if part)
-    headers = {"User-Agent": "Mozilla/5.0"}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/115.0 Safari/537.36"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+    }
     def parse_prices(url):
-        resp = requests.get(url, headers=headers, timeout=10)
-        resp.raise_for_status()
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            st.error(f"Request to {url} failed: {exc}")
+            return None, f"Request failed: {exc}"
+        if resp.status_code != 200:
+            st.error(f"Request to {url} returned status {resp.status_code}")
+            return None, f"Status code {resp.status_code}"
         soup = BeautifulSoup(resp.text, "html.parser")
         prices = []
         for el in soup.select(".s-item__price"):
@@ -27,20 +41,34 @@ def fetch_price_data(card):
                     prices.append(float(match.group(0).replace(",", "")))
                 except ValueError:
                     pass
-        return prices
+        return prices, None
+    error_msgs = []
     try:
         sold_url = f"https://www.ebay.com/sch/i.html?_nkw={query}&LH_Sold=1&LH_Complete=1"
-        sold_prices = parse_prices(sold_url)
-        avg_price = sum(sold_prices)/len(sold_prices) if sold_prices else None
-    except Exception:
+        sold_prices, err = parse_prices(sold_url)
+        if err:
+            error_msgs.append(f"sold prices: {err}")
+            avg_price = None
+        else:
+            avg_price = sum(sold_prices) / len(sold_prices) if sold_prices else None
+    except Exception as exc:
+        st.error(f"Error parsing sold prices: {exc}")
+        error_msgs.append(str(exc))
         avg_price = None
     try:
         listing_url = f"https://www.ebay.com/sch/i.html?_nkw={query}&LH_BIN=1"
-        listing_prices = parse_prices(listing_url)
-        min_listing = min(listing_prices) if listing_prices else None
-    except Exception:
+        listing_prices, err = parse_prices(listing_url)
+        if err:
+            error_msgs.append(f"listing prices: {err}")
+            min_listing = None
+        else:
+            min_listing = min(listing_prices) if listing_prices else None
+    except Exception as exc:
+        st.error(f"Error parsing listing prices: {exc}")
+        error_msgs.append(str(exc))
         min_listing = None
-    return avg_price, min_listing
+    error_message = "; ".join(error_msgs) if error_msgs else None
+    return avg_price, min_listing, error_message
 
 def parse_cards(text):
     cards = []
@@ -71,11 +99,12 @@ if st.button("Fetch Prices"):
     cards = parse_cards(input_text)
     results = []
     for card in cards:
-        avg_price, min_listing = fetch_price_data(card)
+        avg_price, min_listing, error = fetch_price_data(card)
         result = {
             **card,
             "average_sold_price": avg_price,
             "lowest_listing_price": min_listing,
+            "error": error,
         }
         results.append(result)
     if results:


### PR DESCRIPTION
## Summary
- use a full desktop User-Agent in requests
- add optional `Accept-Language` and `Accept` headers
- return informative error messages when price fetch fails

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a9e0ef0883238e9d0a156aa6a138